### PR TITLE
Add Swagger to the project and document SellerController as example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/controller/SellerController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/controller/SellerController.java
@@ -24,14 +24,14 @@ import lombok.RequiredArgsConstructor;
 public class SellerController {
     private final ISellerService sellerService;
 
-    @Operation(summary = "Follow a seller", description = "Allows a user to follow another user who is registered as a seller. This operation updates the user's followed sellers list and the seller's followers list.")
+    @Operation(summary = "Follow a seller", description = "Allows a buyer to follow another user who is registered as a seller. This operation updates the buyer's followed sellers list and the seller's followers list.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully followed the seller. Response body is empty."),
-            @ApiResponse(responseCode = "400", description = "Bad Request: IDs are the same, user or seller not found, or already following.")
+            @ApiResponse(responseCode = "400", description = "Bad Request: IDs are the same, buyer or seller not found, or already following.")
     })
     @PostMapping("/users/{userId}/follow/{userIdToFollow}")
     public ResponseEntity<Void> followSeller(
-            @Parameter(description = "ID of the user who wants to follow the seller", required = true) @PathVariable UUID userId,
+            @Parameter(description = "ID of the buyer who wants to follow the seller", required = true) @PathVariable UUID userId,
             @Parameter(description = "ID of the seller to be followed", required = true) @PathVariable UUID userIdToFollow) {
         sellerService.followSeller(userIdToFollow, userId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/controller/SellerController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/controller/SellerController.java
@@ -11,18 +11,29 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
 import com.mercadolibre.be_java_hisp_w31_g07.service.ISellerService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Seller", description = "Operations related to sellers")
 public class SellerController {
     private final ISellerService sellerService;
 
+    @Operation(summary = "Follow a seller", description = "Allows a user to follow another user who is registered as a seller. This operation updates the user's followed sellers list and the seller's followers list.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully followed the seller. Response body is empty."),
+            @ApiResponse(responseCode = "400", description = "Bad Request: IDs are the same, user or seller not found, or already following.")
+    })
     @PostMapping("/users/{userId}/follow/{userIdToFollow}")
     public ResponseEntity<Void> followSeller(
-            @PathVariable UUID userId,
-            @PathVariable UUID userIdToFollow) {
-        sellerService.followSeller(userId, userIdToFollow);
+            @Parameter(description = "ID of the user who wants to follow the seller", required = true) @PathVariable UUID userId,
+            @Parameter(description = "ID of the seller to be followed", required = true) @PathVariable UUID userIdToFollow) {
+        sellerService.followSeller(userIdToFollow, userId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=be_java_hisp_w31_g07
+# swagger-ui custom path
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
This PR introduces Swagger (Springdoc OpenAPI) to the project to enable automatic API documentation and improve developer experience.

As an example of usage, the `SellerController` has been annotated with Swagger documentation, including:
- `@Tag` for grouping  
- `@Operation` for endpoint summaries  
- `@ApiResponses` for response documentation  
- `@Parameter` for detailed path variable descriptions

This sets a base structure for documenting other controllers moving forward.

http://localhost:8080/swagger-ui/index.html