### PR TITLE
T0001 - Add unit tests for followSeller and findSellerById methods

### DIFF
--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/service/implementations/PostService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/service/implementations/PostService.java
@@ -52,12 +52,15 @@ public class PostService implements IPostService {
     public List<PostResponseDto> findUserPromoPosts(UUID userId) {
         validateExistingSeller(userId);
         List<Post> postList = getPromoPostsOrThrow(userId);
+        
         return mapPostsToDto(postList);
     }
 
     @Override
     public Double findAveragePrice(UUID userId) {
-        return postRepository.findPostsBySellerId(userId).stream().map(post -> {
+        return postRepository.findPostsBySellerId(userId)
+                .stream()
+                .map(post -> {
                     double finalPrice = post.getPrice();
                     if ((post.getHasPromo())) {
                         post.setPrice(finalPrice * (1 - post.getDiscount() / 100.0));

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/service/implementations/SellerService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g07/service/implementations/SellerService.java
@@ -45,7 +45,7 @@ public class SellerService implements ISellerService {
     @Override
     public SellerDto findFollowers(UUID sellerId) {
         Seller seller = sellerRepository.findSellerById(sellerId)
-                .orElseThrow(() -> new BadRequest("Buyer: " + sellerId + " not found"));
+                .orElseThrow(() -> new BadRequest("Seller: " + sellerId + " not found"));
 
         String buyerUserName = userService.findById(seller.getId()).getUserName();
         return BuyerMapper.toSellerDto(seller, buyerUserName, buildUsernamesMap(seller));

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/SellerServiceTest.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/SellerServiceTest.java
@@ -1,0 +1,141 @@
+package com.mercadolibre.be_java_hisp_w31_g07.service;
+
+import com.mercadolibre.be_java_hisp_w31_g07.exception.BadRequest;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Buyer;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
+import com.mercadolibre.be_java_hisp_w31_g07.repository.ISellerRepository;
+import com.mercadolibre.be_java_hisp_w31_g07.service.implementations.SellerService;
+import com.mercadolibre.be_java_hisp_w31_g07.util.BuyerFactory;
+import com.mercadolibre.be_java_hisp_w31_g07.util.SellerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class SellerServiceTest {
+    @InjectMocks
+    private SellerService sellerService;
+
+    @Mock
+    private IBuyerService buyerService;
+
+    @Mock
+    private ISellerRepository sellerRepository;
+
+    private Seller seller;
+    private Buyer buyer;
+    private UUID buyerId;
+    private UUID sellerId;
+
+    @BeforeEach
+    void setUp() {
+        seller = SellerFactory.createSeller();
+        buyer = BuyerFactory.createBuyer();
+        buyerId = buyer.getId();
+        sellerId = seller.getId();
+    }
+
+    @Test
+    void testFollowSellerSuccess() {
+        stubValidBuyerAndSeller();
+
+        sellerService.followSeller(sellerId, buyerId);
+
+        verify(sellerRepository).addBuyerToFollowersList(buyer, sellerId);
+        verify(buyerService).addSellerToFollowedList(seller, buyerId);
+    }
+
+    @Test
+    void testFollowSellerSameUserError() {
+        UUID sameId = UUID.randomUUID();
+
+        BadRequest exception = assertThrows(BadRequest.class, () ->
+                sellerService.followSeller(sameId, sameId)
+        );
+
+        assertEquals("Error message mismatch", "User cannot follow themselves.", exception.getMessage());
+        verifyNoInteractions(sellerRepository, buyerService);
+    }
+
+    @Test
+    void testFollowSellerAlreadyFollowingError() {
+        stubValidBuyerAndSeller();
+        when(sellerRepository.sellerIsBeingFollowedByBuyer(buyer, sellerId)).thenReturn(true);
+        when(buyerService.buyerIsFollowingSeller(seller, buyerId)).thenReturn(true);
+
+        BadRequest exception = assertThrows(BadRequest.class, () ->
+                sellerService.followSeller(sellerId, buyerId)
+        );
+
+        assertEquals("Error message mismatch", "Buyer " + buyer.getId() + " already follows seller "
+                + seller.getId(), exception.getMessage());
+        verify(sellerRepository, never()).addBuyerToFollowersList(buyer, sellerId);
+        verify(buyerService, never()).addSellerToFollowedList(seller, buyerId);
+    }
+
+    @Test
+    void testFollowSellerThatDoesNotExistError() {
+        when(sellerRepository.findSellerById(sellerId)).thenReturn(Optional.empty());
+
+        BadRequest exception = assertThrows(BadRequest.class, () ->
+                sellerService.followSeller(sellerId, buyerId)
+        );
+
+        assertEquals("Error message mismatch", "Seller " + sellerId + " not found", exception.getMessage());
+        verify(sellerRepository, never()).addBuyerToFollowersList(buyer, sellerId);
+        verify(buyerService, never()).addSellerToFollowedList(seller, buyerId);
+    }
+
+    @Test
+    void testFollowSellerButBuyerNotFoundError() {
+        when(sellerRepository.findSellerById(sellerId)).thenReturn(Optional.of(seller));
+        when(buyerService.findBuyerById(buyerId)).thenThrow(new BadRequest("Buyer " + buyerId + " not found"));
+
+        BadRequest exception = assertThrows(BadRequest.class, () ->
+                sellerService.followSeller(sellerId, buyerId)
+        );
+
+        assertEquals("Error message mismatch", "Buyer " + buyerId + " not found", exception.getMessage());
+        verify(sellerRepository, never()).addBuyerToFollowersList(buyer, sellerId);
+        verify(buyerService, never()).addSellerToFollowedList(seller, buyerId);
+    }
+
+    @Test
+    void testFindSellerByIdSuccess() {
+        when(sellerRepository.findSellerById(sellerId)).thenReturn(Optional.of(seller));
+
+        Seller foundSeller = sellerService.findSellerById(sellerId);
+
+        assertEquals("Seller ID mismatch", sellerId, foundSeller.getId());
+        verify(sellerRepository).findSellerById(sellerId);
+        verifyNoMoreInteractions(sellerRepository);
+    }
+
+    @Test
+    void testFindSellerByIdNotFoundError() {
+        when(sellerRepository.findSellerById(sellerId)).thenReturn(Optional.empty());
+
+        BadRequest exception = assertThrows(BadRequest.class, () ->
+                sellerService.findSellerById(sellerId)
+        );
+
+        assertEquals("Error message mismatch", "Seller " + sellerId + " not found", exception.getMessage());
+        verify(sellerRepository).findSellerById(sellerId);
+        verifyNoMoreInteractions(sellerRepository);
+    }
+
+    private void stubValidBuyerAndSeller() {
+        when(buyerService.findBuyerById(buyerId)).thenReturn(buyer);
+        when(sellerRepository.findSellerById(sellerId)).thenReturn(Optional.of(seller));
+    }
+}

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/BuyerFactory.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/BuyerFactory.java
@@ -1,0 +1,33 @@
+package com.mercadolibre.be_java_hisp_w31_g07.util;
+
+import com.mercadolibre.be_java_hisp_w31_g07.model.Buyer;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class BuyerFactory {
+
+    public static Buyer createBuyer() {
+        Buyer buyer = new Buyer();
+        buyer.setId(UUID.randomUUID());
+        buyer.setFollowed(new ArrayList<>());
+        return buyer;
+    }
+
+    public static Buyer createBuyerWithFollowed(List<Seller> sellers) {
+        Buyer buyer = createBuyer();
+        buyer.setFollowed(sellers);
+        return buyer;
+    }
+
+    public static Buyer createBuyerFollowing(Seller... sellers) {
+        Buyer buyer = createBuyer();
+        for (Seller seller : sellers) {
+            buyer.addFollowedSeller(seller);
+        }
+        return buyer;
+    }
+}
+

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/BuyerFactory.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/BuyerFactory.java
@@ -1,10 +1,8 @@
 package com.mercadolibre.be_java_hisp_w31_g07.util;
 
 import com.mercadolibre.be_java_hisp_w31_g07.model.Buyer;
-import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 public class BuyerFactory {
@@ -13,20 +11,6 @@ public class BuyerFactory {
         Buyer buyer = new Buyer();
         buyer.setId(UUID.randomUUID());
         buyer.setFollowed(new ArrayList<>());
-        return buyer;
-    }
-
-    public static Buyer createBuyerWithFollowed(List<Seller> sellers) {
-        Buyer buyer = createBuyer();
-        buyer.setFollowed(sellers);
-        return buyer;
-    }
-
-    public static Buyer createBuyerFollowing(Seller... sellers) {
-        Buyer buyer = createBuyer();
-        for (Seller seller : sellers) {
-            buyer.addFollowedSeller(seller);
-        }
         return buyer;
     }
 }

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/SellerFactory.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/SellerFactory.java
@@ -1,0 +1,34 @@
+package com.mercadolibre.be_java_hisp_w31_g07.util;
+
+import com.mercadolibre.be_java_hisp_w31_g07.model.Buyer;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+public class SellerFactory {
+
+    public static Seller createSeller() {
+        Seller seller = new Seller();
+        seller.setId(UUID.randomUUID());
+        seller.setFollowerCount(0);
+        seller.setFollowers(new ArrayList<>());
+        return seller;
+    }
+
+    public static Seller createSellerWithFollowers(List<Buyer> buyers) {
+        Seller seller = createSeller();
+        for (Buyer buyer : buyers) {
+            seller.addFollower(buyer);
+        }
+        seller.setFollowerCount(buyers.size());
+        return seller;
+    }
+
+    public static Seller createSellerWithFollowers(Buyer... buyers) {
+        return createSellerWithFollowers(Arrays.asList(buyers));
+    }
+}
+

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/SellerFactory.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/SellerFactory.java
@@ -1,11 +1,8 @@
 package com.mercadolibre.be_java_hisp_w31_g07.util;
 
-import com.mercadolibre.be_java_hisp_w31_g07.model.Buyer;
 import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 
 public class SellerFactory {
@@ -16,19 +13,6 @@ public class SellerFactory {
         seller.setFollowerCount(0);
         seller.setFollowers(new ArrayList<>());
         return seller;
-    }
-
-    public static Seller createSellerWithFollowers(List<Buyer> buyers) {
-        Seller seller = createSeller();
-        for (Buyer buyer : buyers) {
-            seller.addFollower(buyer);
-        }
-        seller.setFollowerCount(buyers.size());
-        return seller;
-    }
-
-    public static Seller createSellerWithFollowers(Buyer... buyers) {
-        return createSellerWithFollowers(Arrays.asList(buyers));
     }
 }
 


### PR DESCRIPTION
## Title:
Add unit tests for followSeller and findSellerById methods

## Description:
This PR introduces unit tests for the `followSeller` and `findSellerById` methods in the `SellerService` class. The tests cover various scenarios to ensure the correct behavior of the service methods, including error handling for cases like the user trying to follow themselves, attempting to follow a non-existent seller, or when the buyer is already following the seller.

### Changes:
- Added tests for the `followSeller` method to check for success, errors, and edge cases.
- Added tests for the `findSellerById` method to handle both successful retrieval and errors when the seller is not found.

These tests help improve the reliability and maintainability of the service methods by ensuring that the logic works as expected under different conditions.
