### PR TITLE
T0013 - Add unit tests for findPost method in PostService

### DIFF
--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
@@ -49,7 +49,7 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("[ERROR] Find post - Success")
+    @DisplayName("[SUCCESS] Find post - Success")
     void testFindPostSuccess() {
         PostResponseDto postResponseDto = PostFactory.createPostResponseDto(seller.getId());
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
@@ -10,6 +10,7 @@ import com.mercadolibre.be_java_hisp_w31_g07.util.GenericObjectMapper;
 import com.mercadolibre.be_java_hisp_w31_g07.util.PostFactory;
 import com.mercadolibre.be_java_hisp_w31_g07.util.SellerFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -48,6 +49,7 @@ class PostServiceTest {
     }
 
     @Test
+    @DisplayName("[ERROR] Find post - Success")
     void testFindPostSuccess() {
         PostResponseDto postResponseDto = PostFactory.createPostResponseDto(seller.getId());
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
@@ -62,6 +64,7 @@ class PostServiceTest {
     }
 
     @Test
+    @DisplayName("[ERROR] Find post - Not Found")
     void testFindPostNotFound() {
         when(postRepository.findById(postId)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
@@ -1,0 +1,75 @@
+package com.mercadolibre.be_java_hisp_w31_g07.service;
+
+import com.mercadolibre.be_java_hisp_w31_g07.dto.response.PostResponseDto;
+import com.mercadolibre.be_java_hisp_w31_g07.exception.BadRequest;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Post;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Seller;
+import com.mercadolibre.be_java_hisp_w31_g07.repository.IPostRepository;
+import com.mercadolibre.be_java_hisp_w31_g07.service.implementations.PostService;
+import com.mercadolibre.be_java_hisp_w31_g07.util.GenericObjectMapper;
+import com.mercadolibre.be_java_hisp_w31_g07.util.PostFactory;
+import com.mercadolibre.be_java_hisp_w31_g07.util.SellerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private IPostRepository postRepository;
+
+    @Mock
+    private GenericObjectMapper mapper;
+
+    @InjectMocks
+    private PostService postService;
+
+    private Post post;
+    private UUID postId;
+    private Seller seller;
+
+    @BeforeEach
+    void setUp() {
+        seller = SellerFactory.createSeller();
+        post = PostFactory.createPost(seller.getId());
+        postId = post.getId();
+    }
+
+    @Test
+    void testFindPostSuccess() {
+        PostResponseDto postResponseDto = PostFactory.createPostResponseDto(seller.getId());
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(mapper.map(post, PostResponseDto.class)).thenReturn(postResponseDto);
+
+        PostResponseDto result = postService.findPost(postId);
+
+        assertEquals(postResponseDto, result);
+        verify(postRepository).findById(postId);
+        verify(mapper).map(post, PostResponseDto.class);
+        verifyNoMoreInteractions(postRepository, mapper);
+    }
+
+    @Test
+    void testFindPostNotFound() {
+        when(postRepository.findById(postId)).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(BadRequest.class, () -> postService.findPost(postId));
+
+        assertEquals("Post " + postId + " not found", exception.getMessage());
+        verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+}

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/service/PostServiceTest.java
@@ -39,19 +39,19 @@ class PostServiceTest {
 
     private Post post;
     private UUID postId;
-    private Seller seller;
+    private PostResponseDto postResponseDto;
 
     @BeforeEach
     void setUp() {
-        seller = SellerFactory.createSeller();
+        Seller seller = SellerFactory.createSeller();
         post = PostFactory.createPost(seller.getId());
         postId = post.getId();
+        postResponseDto = PostFactory.createPostResponseDto(seller.getId());
     }
 
     @Test
     @DisplayName("[SUCCESS] Find post - Success")
     void testFindPostSuccess() {
-        PostResponseDto postResponseDto = PostFactory.createPostResponseDto(seller.getId());
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
         when(mapper.map(post, PostResponseDto.class)).thenReturn(postResponseDto);
 

--- a/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/PostFactory.java
+++ b/src/test/java/com/mercadolibre/be_java_hisp_w31_g07/util/PostFactory.java
@@ -1,0 +1,48 @@
+package com.mercadolibre.be_java_hisp_w31_g07.util;
+
+import com.mercadolibre.be_java_hisp_w31_g07.dto.response.PostResponseDto;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Post;
+import com.mercadolibre.be_java_hisp_w31_g07.model.Product;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+public class PostFactory {
+
+    public static Post createPost(UUID sellerId) {
+        UUID postId = UUID.randomUUID();
+        Post post = new Post();
+        post.setId(postId);
+        post.setDate(LocalDate.parse("30-04-2025", DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+        post.setProduct(createProduct(postId));
+        post.setCategory(1);
+        post.setPrice(100.0);
+        post.setSellerId(sellerId);
+        post.setHasPromo(false);
+        post.setDiscount(0.0);
+        return post;
+    }
+
+    public static PostResponseDto createPostResponseDto(UUID postId) {
+        PostResponseDto postResponseDto = new PostResponseDto();
+        postResponseDto.setId(postId);
+        postResponseDto.setDate(LocalDate.parse("30-04-2025", DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+        postResponseDto.setCategory(1);
+        postResponseDto.setPrice(100.0);
+        postResponseDto.setHasPromo(true);
+        postResponseDto.setDiscount(0.1);
+        return postResponseDto;
+    }
+
+    private static Product createProduct(UUID productId) {
+        Product product = new Product();
+        product.setId(productId);
+        product.setProductName("Test product");
+        product.setType("Test type");
+        product.setBrand("Test Brand");
+        product.setColor("Test Color");
+        product.setNote("Test Note");
+        return product;
+    }
+}


### PR DESCRIPTION
## Title:
Add unit tests for findPost method in PostService

## Description:
This PR adds unit tests for the `findPost` method in the `PostService` class. The tests cover both successful retrieval and error handling when the post is not found.

### Changes:
- Added a test for successful retrieval of a post and proper mapping to `PostResponseDto`.
- Added a test to verify behavior when the post does not exist, expecting a `BadRequest` exception.
- Used `verifyNoMoreInteractions` to ensure no unnecessary dependencies are invoked.

These tests help ensure the service behaves correctly under different conditions and that external dependencies are used as expected.